### PR TITLE
Add reports route

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -12,8 +12,13 @@
       "dest": "/static/$1"
     },
     {
+      "src": "/reports/(.*)",
+      "dest": "/reports/$1"
+    },
+    {
       "src": "/(.*)",
       "dest": "/index.html"
     }
   ]
-} 
+}
+


### PR DESCRIPTION
## Summary
- serve reports directly via Vercel by adding `/reports` route

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_b_685922945b0483319bfbb904ff726fd4