### PR TITLE
Use env variable for login password

### DIFF
--- a/src/components/Login.js
+++ b/src/components/Login.js
@@ -23,7 +23,14 @@ const Login = ({ onLogin }) => {
 
   const handleSubmit = (e) => {
     e.preventDefault();
-    if (password === '1234') {
+    const envPassword = process.env.REACT_APP_LOGIN_PASSWORD;
+
+    if (!envPassword) {
+      setError('Login is not configured. Please contact the administrator.');
+      return;
+    }
+
+    if (password === envPassword) {
       onLogin(true);
     } else {
       setError('Invalid password. Please try again.');


### PR DESCRIPTION
## Summary
- read password from `REACT_APP_LOGIN_PASSWORD`
- show configuration error if password is missing

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_b_685928003f70833182eff32ae0fe02e3